### PR TITLE
Changing windows install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The Windows build comes with an INF file to make installation easy.
 
  1. Open `.windows/` folder in Explorer, and right click on `install.inf`.
  1. Click 'Install' from the context menu, and authorise the modifications to your system.
- 1. Press the `Windows Key and R` at the same time and type `main.cpl` in the run promt.
+ 1. Press the `Windows Key and R` at the same time and type `main.cpl` in the run promt and press `Ok`.
  1. Go to `Pointers` and select `Vimix Cursors` under the Scheme category.
  1. Click 'Apply'.
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ Then set the theme with your preferred desktop tools.
 
 The Windows build comes with an INF file to make installation easy.
 
- 1. Open `.windows/` in Explorer, and right click on `install.inf`.
- 2. Click 'Install' from the context menu, and authorise the modifications to your system.
- 3. Open `Control Panel` > `Personalisation and Appearance` > `Change mouse pointers`, and select Capitaine cursors.
- 4. Click 'Apply'.
+ 1. Open `.windows/` folder in Explorer, and right click on `install.inf`.
+ 1. Click 'Install' from the context menu, and authorise the modifications to your system.
+ 1. Press the `Windows Key and R` at the same time and type `main.cpl` in the run promt.
+ 1. Go to `Pointers` and select `Vimix Cursors` under the Scheme category.
+ 1. Click 'Apply'.
 
 ## Building from source
 You'll find everything you need to build and modify this cursor set in


### PR DESCRIPTION
## Issue
Step three in the installation process for [Windows](https://github.com/vinceliuice/Vimix-cursors#windows), the option `Change mouse pointers` is no longer under `Personalisation and Appearance` as you can see [here](https://gyazo.com/6376379f673de8b5ac2a7394cee1fd84 "Gyazo - Appearance and Personalisation").

## Solution
I would tell the user to use the Windows [Run promt](https://gyazo.com/823960cfef2a1535888aaed657b8a389 "Gyazo - Run"). Typing in `main.cpl` and pressing `OK` will skip all the hassle of navigating through the Control Panel and go straight to the [Mouse Properties](https://gyazo.com/9645c8110d55e1f75d763271e16003e9 "Gyazo - Mouse Properties") settings.
