### PR TITLE
Removed error when calling install.sh outside the folder

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 
+# Source: https://stackoverflow.com/a/246128
+SOURCE=${BASH_SOURCE[0]}
+while [ -L "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    SCRIPT_DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+    SOURCE=$(readlink "$SOURCE")
+    [[ $SOURCE != /* ]] && SOURCE=$SCRIPT_DIR/$SOURCE # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+SCRIPT_DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+#echo "Script dir: $SCRIPT_DIR"
+# ==========================================
+
 ROOT_UID=0
 DEST_DIR=
 
@@ -19,8 +30,7 @@ if [ -d "$DEST_DIR/Vimix-white-cursors" ]; then
   rm -rf "$DEST_DIR/Vimix-white-cursors"
 fi
 
-cp -r dist/ $DEST_DIR/Vimix-cursors
-cp -r dist-white/ $DEST_DIR/Vimix-white-cursors
+cp -r $SCRIPT_DIR/dist/ $DEST_DIR/Vimix-cursors
+cp -r $SCRIPT_DIR/dist-white/ $DEST_DIR/Vimix-white-cursors
 
 echo "Finished..."
-


### PR DESCRIPTION
When you call install.sh outside the script folder as in the example:
```bash
~/Vimix-cursors/install.sh
```

Returns:
```bash
cp: cannot stat 'dist/': No such file or directory
cp: cannot stat 'dist-white/': No such file or directory
```
Because the script refers to the current folder and not the script folder